### PR TITLE
Fix race condition that can create multiple iframes

### DIFF
--- a/reveald3.js
+++ b/reveald3.js
@@ -301,13 +301,13 @@ var Reveald3 = window.Reveald3 || (function(){
         // This can be overridden using the data-overflow-shown=true attribute
         container.style.overflow = (container.style.overflow=="" && !JSON.parse(container.getAttribute('data-overflow-shown'))) ? 'hidden' : container.style.overflow
 
-        // continue only if iframe hasn't been created already for this container
-        const iframeList = container.querySelectorAll('iframe')
-        if (iframeList.length>0) return;
-
         const fileExists = !options.disableCheckFile ? await doesFileExist( options.mapPath + file ) : true
         console.log(fileExists)
         const filePath = (options.tryFallbackURL && fileExists) ? options.mapPath + file : file
+
+        // continue only if iframe hasn't been created already for this container
+        const iframeList = container.querySelectorAll('iframe')
+        if (iframeList.length>0) return;
 
         // generate styles string
         const styles = Object.entries(iframeStyle)


### PR DESCRIPTION
This change fixes a race condition on reveald3 whereas sometimes multiple iframes can get created. 

Because the check for the presence of previous iframes was previously done before an `await` statement, two calls to `initialize` can happen concurrently, both of them get an empty list, both of them asynchronously `await`, and both of them create the new `iframe`. By checking for the presence of the iframe and creating an iframe inside the same synchronous block, we guarantee no race conditions.